### PR TITLE
Shave one instruction off each of these functions

### DIFF
--- a/src/maths.c
+++ b/src/maths.c
@@ -4,8 +4,8 @@
 // Limiting prime size to 63 bits stops this overflowing
 uint64_t add_mod_u64(uint64_t x, uint64_t y, uint64_t p) {
   x += y;
-  if (x >= p) x -= p;
-  return x;
+  int64_t maybe = x - p;
+  return maybe < 0 ? x : (uint64_t) maybe;
 }
 
 uint64_t mul_mod_u64(uint64_t x, uint64_t y, uint64_t p) {
@@ -43,8 +43,8 @@ uint64_t mont_mul(uint64_t a, uint64_t b, uint64_t p, uint64_t p_dash) {
   uint64_t m = (uint64_t)t * p_dash;
   uint128_t u = t + (uint128_t)m * p;
   uint64_t res = u >> 64;
-  if (res >= p) res -= p;
-  return res;
+  int64_t maybe = res - p;
+  return maybe < 0 ? res : (uint64_t) maybe;
 }
 
 inline uint64_t sub_mod_u64(uint64_t x, uint64_t y, uint64_t p) {
@@ -107,5 +107,6 @@ uint64_t mont_mul_sub(uint64_t a1, uint64_t b1, uint64_t a2, uint64_t b2, uint64
   uint128_t t = t1 + ((uint128_t)p << 64) - t2;
   uint64_t m = (uint64_t)t * p_dash;
   uint64_t u = (t + (uint128_t)m * p) >> 64;
-  return (u >= p) ? u - p : u;
+  int64_t maybe = u - p;
+  return maybe < 0 ? u : (uint64_t) maybe;
 }


### PR DESCRIPTION
This is 1 instruction shorter per godbolt. Looks like it it's only good for 0.5% speedup though.